### PR TITLE
BUG: Change to postsolver to create results file used by adaptor

### DIFF
--- a/adapt_cylinder/polydata-tetgen/adaptor_cylinder.tcl
+++ b/adapt_cylinder/polydata-tetgen/adaptor_cylinder.tcl
@@ -248,12 +248,12 @@ after 5000
 #
 #  Run the post solver to get just the ybar from the solution
 #
-puts "Running Post Solver for ybar"
+puts "Running Post Solver for first run"
 set adapt_step [expr int($timesteps)]
 set adapt_start $adapt_step
-if [catch {exec $POSTSOLVER -none -sn $adapt_step -indir $fullsimdir -outdir $fullsimdir -ybar} msg] {
+if [catch {exec $POSTSOLVER -start 0 -stop $total_timesteps -incr 1 -indir $fullsimdir -outdir $fullsimdir -vtkcombo -vtu cylinder_results.vtu -vtp cylinder_results.vtp} msg] {
   puts $msg
-  return -code error "ERROR creating ybar file!"
+  return -code error "ERROR running postsolver!"
 }
 puts $msg
 


### PR DESCRIPTION
Fixed error for no cylinder_results.vtu in adaptor tests